### PR TITLE
Fix DB URI handling

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -2,7 +2,10 @@ const port = process.env.PORT || 3008;
 const origin = process.env.NODE_ENV === 'production'
   ? 'https://spaceterra.herokuapp.com'
   : `http://localhost:${port}`;
-const mongoUri = process.env.NODE_ENV === 'production'
-  ? process.env.MONGODB_URI
-  : 'mongodb://127.0.0.1/spaceterra';
+// Allow overriding the MongoDB connection string via the MONGODB_URI
+// environment variable. This lets local development specify a different
+// database URL such as mongodb://127.0.0.1:27017 while production can use the
+// value configured on the host. If the variable isn't provided, fall back to
+// a local database named "spaceterra".
+const mongoUri = process.env.MONGODB_URI || 'mongodb://127.0.0.1/spaceterra';
 module.exports = { port, origin, mongoUri };

--- a/server.js
+++ b/server.js
@@ -14,10 +14,12 @@ const io = socketio(server, {
   },
 });
 
-const uri = "mongodb://127.0.0.1:27017";
-const client = new MongoClient(uri, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true
+// Use the configured MongoDB URI. The value can be overridden with the
+// MONGODB_URI environment variable for local testing or production
+// deployments, and otherwise defaults to the local spaceterra database.
+const client = new MongoClient(config.mongoUri, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
 });
 
 client.connect(err => {


### PR DESCRIPTION
## Summary
- allow overriding the MongoDB connection string via `MONGODB_URI`
- clarify the comment in `server.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ece4120c4832aacab72071ec6d81e