### PR TITLE
Add Google OAuth login

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,44 @@
 const express = require('express');
 const path = require('path');
+const session = require('express-session');
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const config = require('./config');
+
 const app = express();
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
+
+app.use(
+  session({
+    secret: 'change_this_secret',
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+
+app.use(passport.initialize());
+app.use(passport.session());
+
+passport.serializeUser((user, done) => {
+  done(null, user);
+});
+
+passport.deserializeUser((obj, done) => {
+  done(null, obj);
+});
+
+passport.use(
+  new GoogleStrategy(
+    {
+      clientID: config.googleClientID,
+      clientSecret: config.googleClientSecret,
+      callbackURL: '/auth/google/callback',
+    },
+    (accessToken, refreshToken, profile, done) => done(null, profile)
+  )
+);
 
 app.set('views', path.join(__dirname, 'views'));
 app.engine('html', require('ejs').renderFile);
@@ -11,6 +46,61 @@ app.set('view engine', 'html');
 
 app.get('/', (req, res) => {
   res.render('index');
+});
+
+app.get('/auth/google', passport.authenticate('google', {
+  scope: ['profile', 'email'],
+}));
+
+app.get(
+  '/auth/google/callback',
+  passport.authenticate('google', { failureRedirect: '/' }),
+  (req, res) => {
+    res.redirect('/');
+  }
+);
+
+app.get('/api/user', (req, res) => {
+  res.json({ user: req.user || null });
+});
+
+app.get('/api/user/stats', async (req, res, next) => {
+  if (!req.user) {
+    return res.json({ score: null, rank: null });
+  }
+
+  try {
+    const db = req.app.locals.db;
+    if (!db) {
+      throw new Error('Database not initialized');
+    }
+    const leaderboard = db.collection('leaderboard');
+    const username = req.user.displayName || req.user.email;
+
+    const topEntry = await leaderboard
+      .find({ username })
+      .sort({ score: -1 })
+      .limit(1)
+      .toArray();
+
+    const score = topEntry[0] ? topEntry[0].score : 0;
+
+    const betterCount = await leaderboard.countDocuments({ score: { $gt: score } });
+    const rank = score > 0 ? betterCount + 1 : null;
+
+    res.json({ score, rank });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.get('/logout', (req, res, next) => {
+  req.logout(err => {
+    if (err) {
+      return next(err);
+    }
+    res.redirect('/');
+  });
 });
 
 module.exports = app;

--- a/config/index.js
+++ b/config/index.js
@@ -8,4 +8,7 @@ const origin = process.env.NODE_ENV === 'production'
 // value configured on the host. If the variable isn't provided, fall back to
 // a local database named "spaceterra".
 const mongoUri = process.env.MONGODB_URI || 'mongodb://127.0.0.1/spaceterra';
-module.exports = { port, origin, mongoUri };
+const googleClientID = process.env.GOOGLE_CLIENT_ID || '';
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET || '';
+
+module.exports = { port, origin, mongoUri, googleClientID, googleClientSecret };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,11 @@
       "dependencies": {
         "ejs": "^3.1.7",
         "express": "^4.17.1",
+        "express-session": "^1.18.1",
         "http": "0.0.1-security",
         "mongodb": "^3.6.4",
+        "passport": "^0.7.0",
+        "passport-google-oauth20": "^2.0.0",
         "socket.io": "^3.1.1"
       },
       "devDependencies": {
@@ -1462,6 +1465,15 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
@@ -2355,6 +2367,69 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-session/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4118,6 +4193,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4133,6 +4214,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4258,6 +4348,64 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4299,6 +4447,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4456,6 +4609,15 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -5089,6 +5251,24 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,11 @@
   "dependencies": {
     "ejs": "^3.1.7",
     "express": "^4.17.1",
+    "express-session": "^1.18.1",
     "http": "0.0.1-security",
     "mongodb": "^3.6.4",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
     "socket.io": "^3.1.1"
   },
   "engines": {

--- a/public/javascripts/game.js
+++ b/public/javascripts/game.js
@@ -10,6 +10,7 @@ var distance = 0;
 var pause_button;
 var fullButton, muteButton;
 var username;
+var statsText;
 var leader;
 var video, button, sprite, logoimg;
 var time, tempY;

--- a/public/javascripts/states/landing.js
+++ b/public/javascripts/states/landing.js
@@ -63,21 +63,34 @@ function create1() {
     fullButton = game.add.button(70, 90, 'fullButton', goFull, this, 2, 1, 0);
     fullButton.scale.setTo(0.5, 0.5);
 
-    if (username == null) {
-        while (true) {
-            username = prompt("Enter username: ");
+    statsText = game.add.text(350, 370, '', { fontSize: '24px', fill: '#F8E22E' });
+    statsText.anchor.setTo(0.5, 0.5);
 
-            if (username == '' || username == null) {
-                // user pressed OK, but username invalid or does not username anything
-                alert("Invalid username.");
-            } else {
-                // user typed something valid and hit OK
-                return username;
-            }
-        }
+    if (username == null) {
+        fetch('/api/user')
+            .then(function (res) { return res.json(); })
+            .then(function (data) {
+                if (data.user) {
+                    username = data.user.displayName || data.user.email;
+                    loadStats();
+                } else {
+                    window.location = '/auth/google';
+                }
+            });
+    } else {
+        loadStats();
     }
 
 
+}
+function loadStats() {
+    fetch('/api/user/stats')
+        .then(function (res) { return res.json(); })
+        .then(function (data) {
+            if (data && data.score != null && data.rank != null) {
+                statsText.text = 'High Score: ' + data.score + ' (Rank ' + data.rank + ')';
+            }
+        });
 }
 function update1() {
     if (game.sound.mute) {

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ client.connect(err => {
   console.log('Connection to DB established!');
   console.log(config.mongoUri);
   const db = client.db('spaceterra');
+  app.locals.db = db;
   require('./sockets/leaderboard')(io, db);
 });
 

--- a/test/game1.test.js
+++ b/test/game1.test.js
@@ -16,6 +16,8 @@ function loadGame() {
     console: { log: () => {} },
     prompt: () => 'test',
     alert: () => {},
+    fetch: () => Promise.resolve({ json: () => Promise.resolve({}) }),
+    window: { CONFIG: { origin: '' } },
     Phaser: {
       CANVAS: 0,
       Keyboard: { M: 0, F: 0 },

--- a/views/index.html
+++ b/views/index.html
@@ -39,6 +39,16 @@
     <script type="text/javascript" src="/javascripts/states/instructions.js"></script>
     <script type="text/javascript" src="/javascripts/config.js"></script>
     <script type="text/javascript" src="/javascripts/game.js"></script>
+    <a href="/logout" id="logout" style="position:absolute;top:10px;right:10px;display:none;color:#fff;z-index:1000">Logout</a>
+    <script>
+      fetch('/api/user')
+        .then(function(res){return res.json();})
+        .then(function(data){
+          if(data.user){
+            document.getElementById('logout').style.display = 'block';
+          }
+        });
+    </script>
   </div>
 
   <label></label>


### PR DESCRIPTION
## Summary
- add Google OAuth strategy with passport
- expose user session API and logout route
- fetch logged-in user on the landing page and redirect to Google sign-in
- show a logout link on the main page
- update tests for fetch and window globals
- show logged-in player's high score and leaderboard rank

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686edb4bf8f0832aabf65c36b61b6e85